### PR TITLE
Revert "Change protocol confirmation function as it is now deprecated"

### DIFF
--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -2,8 +2,6 @@
 
 module LDAP;
 
-@load base/misc/version
-
 export {
   redef enum Log::ID += { LDAP_LOG,
                           LDAP_SEARCH_LOG };
@@ -286,11 +284,7 @@ function set_session(c: connection, message_id: int, opcode: LDAP::ProtocolOpcod
 }
 
 #############################################################################
-@if (Version::at_least("4.2.0"))
-event analyzer_confirmation(c: connection, atype: Analyzer::Tag, aid: count) {
-@else
-event protocol_confirmation(c: connection, atype: AllAnalyzers::Tag, aid: count) {
-@endif
+event protocol_confirmation(c: connection, atype: Analyzer::Tag, aid: count) &priority=5 {
 
   if ( atype == Analyzer::ANALYZER_SPICY_LDAP_TCP ) {
     c$ldap_proto = "tcp";


### PR DESCRIPTION
This reverts commit 70b186e926a19501122fb7c616dc5008c195ac87. The
follow-up work to make this actually work is tracked in #10.