### PR TITLE
Use symbols from `spicy` instead of `hilti` runtime library.

### DIFF
--- a/analyzer/asn1.spicy
+++ b/analyzer/asn1.spicy
@@ -140,7 +140,7 @@ type ASN1OctetString = unit(len: uint64, constructed: bool) {
 # https://www.obj-sys.com/asn1tutorial/node124.html
 
 type ASN1String = unit(tag: ASN1Tag, len: uint64) {
-  var encoding: hilti::Charset;
+  var encoding: spicy::Charset;
 
   on %init {
     switch ( tag.type_ ) {
@@ -151,7 +151,7 @@ type ASN1String = unit(tag: ASN1Tag, len: uint64) {
       case ASN1Type::PrintableString,
            ASN1Type::GeneralizedTime,
            ASN1Type::UTCTime: {
-        self.encoding = hilti::Charset::ASCII;
+        self.encoding = spicy::Charset::ASCII;
       }
 
       case ASN1Type::UTF8String,
@@ -167,7 +167,7 @@ type ASN1String = unit(tag: ASN1Tag, len: uint64) {
            # BMPString and UniversalString. This *may* not be correct.
            ASN1Type::BMPString,
            ASN1Type::UniversalString: {
-        self.encoding = hilti::Charset::UTF8;
+        self.encoding = spicy::Charset::UTF8;
       }
     }
   }
@@ -235,7 +235,7 @@ public type ASN1Body = unit(head: ASN1Header, recursive: bool) {
     ASN1Type::BitString -> bitstr_value: ASN1BitString(head.len.len, head.tag.constructed);
 
     ASN1Type::OctetString -> str_value: ASN1OctetString(head.len.len, head.tag.constructed)
-                                        &convert=$$.value.decode(hilti::Charset::ASCII);
+                                        &convert=$$.value.decode(spicy::Charset::ASCII);
 
     ASN1Type::ObjectIdentifier -> str_value: ASN1ObjectIdentifier(head.len.len)
                                              &convert=$$.oidstring;

--- a/analyzer/ldap.spicy
+++ b/analyzer/ldap.spicy
@@ -733,7 +733,7 @@ type SearchFilter = unit {
     FilterType::FILTER_EXT     -> FILTER_EXT:     DecodedAttributeValue(FilterType::FILTER_EXT)
                                                   &parse-from=self.filterBytes;
     FilterType::FILTER_PRESENT -> FILTER_PRESENT: ASN1::ASN1OctetString(self.filterLen, False)
-                                                  &convert=$$.value.decode(hilti::Charset::ASCII)
+                                                  &convert=$$.value.decode(spicy::Charset::ASCII)
                                                   &parse-from=self.filterBytes;
   };
 


### PR DESCRIPTION
Previously Spicy would allow references to `hilti`, even though names from `spicy` should have been used. The most recent development version of Spicy got more strict here, so the code as written is now rejected.

This patch fixes the Spicy code to use symbols from `spicy` instead of `hilti`. We also add previously implicitly available imports.